### PR TITLE
Fix: Move file upload to left side bar

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,10 @@
+### UPDATED START
+# Move the file uploader to the sidebar
+uploaded_file = st.sidebar.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END
+
+### UPDATED START
+# Remove the file uploader from the main area
+# st.markdown("Upload a PostgreSQL log file")
+# uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END


### PR DESCRIPTION
Auto-generated update for issue:

Goal: Relocate file upload controls from the main area to the left sidebar to free the main pane for analysis.

Description:
Update the UI so users select/drag files using st.sidebar.file_uploader. Preserve multiple-file support, type filters, and clear instructions.

Acceptance Criteria

File upload widget appears in the left sidebar.

Multiple files can be uploaded (if previously supported).

Allowed file types and max size are enforced as before.

Clear helper text/tooltips are shown in the sidebar.

No upload controls remain in the main pane