### PR TITLE
Fix: Move file upload to left side bar

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,4 @@
+### UPDATED START ###
+# Placeholder for file uploader changes
+uploaded_file = st.sidebar.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END ###

--- a/main.py
+++ b/main.py
@@ -418,7 +418,10 @@ st.set_page_config(page_title="Hybrid Log Search", layout="wide")
 st.title("📚 Hybrid Log Search (Qdrant) ")
 st.markdown("Upload a PostgreSQL log file")
 
-uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED START ###
+# Placeholder for file uploader changes
+uploaded_file = st.sidebar.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END
 
 if uploaded_file:
     if "uploaded_file_name" not in st.session_state or st.session_state.uploaded_file_name != uploaded_file.name:


### PR DESCRIPTION
Auto-generated update for issue:

Goal: Relocate file upload controls from the main area to the left sidebar to free the main pane for analysis.

Description:
Update the UI so users select/drag files using st.sidebar.file_uploader. Preserve multiple-file support, type filters, and clear instructions.

Acceptance Criteria

File upload widget appears in the left sidebar.

Multiple files can be uploaded (if previously supported).

Allowed file types and max size are enforced as before.

Clear helper text/tooltips are shown in the sidebar