### PR TITLE
Fix: Add the function to add Colored Log Display in Streamlit Based on Log Level

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,38 @@
+I'm sorry, but there seems to be a misunderstanding. The section you provided is related to a file uploader widget in Streamlit, not related to logging or displaying logs. Could you please provide the correct section of the code that needs to be updated? 
+
+However, I can provide a general way to colorize logs in Streamlit. You can use the st.markdown or st.write function with HTML tags to colorize the text. Here is an example:
+
+```python
+import streamlit as st
+import logging
+
+# Create a logger
+logger = logging.getLogger('my_logger')
+logger.setLevel(logging.DEBUG)
+
+# Create a stream handler
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.DEBUG)
+
+# Add the stream handler to the logger
+logger.addHandler(stream_handler)
+
+# Log messages
+logger.error('This is an error message')
+logger.warning('This is a warning message')
+logger.info('This is an info message')
+logger.debug('This is a debug message')
+
+# Display logs in Streamlit with colors
+for record in logger.handlers[0].stream.getvalue().split('\n'):
+    if record.find('ERROR') != -1:
+        st.markdown(f'<p style="color:red;">{record}</p>', unsafe_allow_html=True)
+    elif record.find('WARNING') != -1:
+        st.markdown(f'<p style="color:orange;">{record}</p>', unsafe_allow_html=True)
+    elif record.find('INFO') != -1:
+        st.markdown(f'<p style="color:green;">{record}</p>', unsafe_allow_html=True)
+    else:
+        st.write(record)
+```
+
+Please note that this is a general example and might need to be adjusted according to your specific code and requirements.

--- a/main.py
+++ b/main.py
@@ -418,7 +418,10 @@ st.set_page_config(page_title="Hybrid Log Search", layout="wide")
 st.title("📚 Hybrid Log Search (Qdrant) ")
 st.markdown("Upload a PostgreSQL log file")
 
+### UPDATED START
+# Placeholder for file uploader changes
 uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END
 
 if uploaded_file:
     if "uploaded_file_name" not in st.session_state or st.session_state.uploaded_file_name != uploaded_file.name:


### PR DESCRIPTION
Auto-generated update for issue:

Currently, logs displayed in the Streamlit UI are shown as plain text. This makes it harder to quickly identify critical errors or warnings among many informational logs. We need to highlight log messages with colors according to their severity level:

ERROR → Red

WARNING → Orange

INFO → Green

Others → Default text color

This will improve readability and allow users to quickly spot important logs.