### PR TITLE
Fix: update UI

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,20 @@
+```python
+### SECTION ###
+# placeholder
+uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+
+# Function to color log messages based on their level
+def color_log_message(level, message):
+    if level == "ERROR":
+        return f'<span style="color:red;">{message}</span>'
+    elif level == "WARNING":
+        return f'<span style="color:orange;">{message}</span>'
+    elif level == "INFO":
+        return f'<span style="color:green;">{message}</span>'
+    else:
+        return message  # Default to black for other levels
+
+# Example usage in log display
+for log in logs:
+    st.markdown(color_log_message(log.level, log.message), unsafe_allow_html=True)
+```

--- a/main.py
+++ b/main.py
@@ -418,7 +418,10 @@ st.set_page_config(page_title="Hybrid Log Search", layout="wide")
 st.title("📚 Hybrid Log Search (Qdrant) ")
 st.markdown("Upload a PostgreSQL log file")
 
+### UPDATED START 34958ff7 ###
+# placeholder
 uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+### UPDATED END 34958ff7 ###
 
 if uploaded_file:
     if "uploaded_file_name" not in st.session_state or st.session_state.uploaded_file_name != uploaded_file.name:


### PR DESCRIPTION
Auto-generated update for issue:

Description:
Currently, log messages are displayed in plain text. Update the UI so that log messages with ERROR level are displayed in red color, WARNING in orange, and INFO in green. Other levels remain black.

Acceptance Criteria:

Log messages with ERROR appear in red.

WARNING messages appear in orange.

INFO messages appear in green.

All other messages remain black.

The color coding should apply both in the main log display and in cluster views.

No changes to functionality of indexing or searching logs.