### PR TITLE
Fix: Add search box for log filtering

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,26 @@
+```python
+# placeholder
+uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+
+# Add search box for log filtering
+search_keyword = st.text_input("Search logs")
+
+# Filter logs based on search keyword
+if uploaded_file is not None:
+    logs = read_logs(uploaded_file)  # Assuming this function reads the logs from the uploaded file
+    if search_keyword:
+        filtered_logs = [log for log in logs if search_keyword.lower() in log.lower()]
+    else:
+        filtered_logs = logs
+
+    # Display filtered logs with existing color formatting
+    for log in filtered_logs:
+        if "ERROR" in log:
+            st.markdown(f"<span style='color:red'>{log}</span>", unsafe_allow_html=True)
+        elif "WARNING" in log:
+            st.markdown(f"<span style='color:orange'>{log}</span>", unsafe_allow_html=True)
+        elif "INFO" in log:
+            st.markdown(f"<span style='color:green'>{log}</span>", unsafe_allow_html=True)
+        else:
+            st.markdown(log)
+```

--- a/main.py
+++ b/main.py
@@ -420,7 +420,32 @@ st.markdown("Upload a PostgreSQL log file")
 
 ### UPDATED START c1b626ad ###
 # placeholder
+### UPDATED START 248e51a3 ###
+# placeholder
 uploaded_file = st.file_uploader("📁 Upload a .txt, .pdf, or .docx file", type=["txt", "pdf", "docx"])
+
+# Add search box for log filtering
+search_keyword = st.text_input("Search logs")
+
+# Filter logs based on search keyword
+if uploaded_file is not None:
+    logs = read_logs(uploaded_file)  # Assuming this function reads the logs from the uploaded file
+    if search_keyword:
+        filtered_logs = [log for log in logs if search_keyword.lower() in log.lower()]
+    else:
+        filtered_logs = logs
+
+    # Display filtered logs with existing color formatting
+    for log in filtered_logs:
+        if "ERROR" in log:
+            st.markdown(f"<span style='color:red'>{log}</span>", unsafe_allow_html=True)
+        elif "WARNING" in log:
+            st.markdown(f"<span style='color:orange'>{log}</span>", unsafe_allow_html=True)
+        elif "INFO" in log:
+            st.markdown(f"<span style='color:green'>{log}</span>", unsafe_allow_html=True)
+        else:
+            st.markdown(log)
+### UPDATED END 248e51a3 ###
 
 # Function to color log messages based on their level
 def color_log_message(level, message):


### PR DESCRIPTION
Auto-generated update for issue:

Acceptance Criteria:

Add a simple text input box (st.text_input) above the log display.

When a user types in the search box, only logs containing the search keyword should be shown.

Case-insensitive search.

If the box is empty, show all logs.

Do not change existing color formatting (ERROR = red, WARNING = orange, INFO = green, others = black).