### PR TITLE
Fix: Add search box for filtering

### DIFF
--- a/changes.py
+++ b/changes.py
@@ -1,0 +1,19 @@
+```python
+# placeholder
+search_keyword = st.text_input("Search logs", "").strip().lower()
+
+filtered_logs = [
+    log for log in logs 
+    if search_keyword in log.lower() or not search_keyword
+]
+
+for log in filtered_logs:
+    if "ERROR" in log:
+        st.markdown(f"<span style='color:red'>{log}</span>", unsafe_allow_html=True)
+    elif "WARNING" in log:
+        st.markdown(f"<span style='color:orange'>{log}</span>", unsafe_allow_html=True)
+    elif "INFO" in log:
+        st.markdown(f"<span style='color:green'>{log}</span>", unsafe_allow_html=True)
+    else:
+        st.markdown(f"<span style='color:black'>{log}</span>", unsafe_allow_html=True)
+```

--- a/main.py
+++ b/main.py
@@ -71,6 +71,25 @@ def connect_pg():
         host=PG_HOST,
         port=PG_PORT
     )
+### UPDATED START c703f66c ###
+# placeholder
+search_keyword = st.text_input("Search logs", "").strip().lower()
+
+filtered_logs = [
+    log for log in logs 
+    if search_keyword in log.lower() or not search_keyword
+]
+
+for log in filtered_logs:
+    if "ERROR" in log:
+        st.markdown(f"<span style='color:red'>{log}</span>", unsafe_allow_html=True)
+    elif "WARNING" in log:
+        st.markdown(f"<span style='color:orange'>{log}</span>", unsafe_allow_html=True)
+    elif "INFO" in log:
+        st.markdown(f"<span style='color:green'>{log}</span>", unsafe_allow_html=True)
+    else:
+        st.markdown(f"<span style='color:black'>{log}</span>", unsafe_allow_html=True)
+### UPDATED END c703f66c ###
 
 def ensure_table_exists():
     conn = connect_pg()


### PR DESCRIPTION
Auto-generated update for issue:

Acceptance Criteria:

Add a simple text input box (st.text_input) above the log display.

When a user types in the search box, only logs containing the search keyword should be shown.

Case-insensitive search.

If the box is empty, show all logs.

Do not change existing color formatting (ERROR = red, WARNING = orange, INFO = green, others = black).